### PR TITLE
add ability to set TLS configuration options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+.gradle
+build
+out
+*.iml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,3 +3,4 @@
 
 # 0.0.2 (2018-01-22)
 - Modify default config to match MQ Docker container image defaults
+- add TLS related properties

--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ mq.password=passw0rd
 
 Spring Boot will then create a ConnectionFactory that can then be used to interact with your queue manager.
 
+#### TLS related options
+The following options all default to null, but may be used to assist with configuring TLS
+
+| Option                  | Description                                                                     |
+| ----------------------- | -----------                                                                     |
+| mq.sslCipherSuite    | Cipher Suite, sets connectionFactory property WMQConstants.WMQ_SSL_CIPHER_SUITE | 
+| mq.sslCipherSpec     | Cipher Spec,  sets connectionFactory property WMQConstants.WMQ_SSL_CIPHER_SPEC  |
+| mq.useIBMCipherMappings | Sets System property com.ibm.mq.cfg.useIBMCipherMappings                        |
+
 ## Related documentation
 * [MQ documentation](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.0.0/com.ibm.mq.helphome.v90.doc/WelcomePagev9r0.htm)
 * [Spring Boot documentation](https://projects.spring.io/spring-boot/)

--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ subprojects {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter', version: springBootVersion
     
     // Testing
-    //testCompile group: 'junit', name: 'junit', version: '4.12'
-    //testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion
   }
 
   // Include variable debug info in the compiled classes

--- a/mq-jms-spring-boot-starter/src/main/java/com/ibm/mq/spring/boot/MQConfigurationProperties.java
+++ b/mq-jms-spring-boot-starter/src/main/java/com/ibm/mq/spring/boot/MQConfigurationProperties.java
@@ -50,8 +50,14 @@ public class MQConfigurationProperties {
 
 	/** MQ password */
 	private String password = "passw0rd";
+
+	private String sslCipherSuite;
+
+	private String sslCipherSpec;
+
+	private boolean useIBMCipherMappings = true;
 	
-  public String getQueueManager() {
+	public String getQueueManager() {
 		return queueManager;
 	}
 
@@ -90,5 +96,29 @@ public class MQConfigurationProperties {
 	public void setPassword(String password) {
 		this.password = password;
 	}
-	
+
+	public String getSslCipherSuite() {
+		return sslCipherSuite;
+	}
+
+	public void setSslCipherSuite(String sslCipherSuite) {
+		this.sslCipherSuite = sslCipherSuite;
+	}
+
+	public String getSslCipherSpec() {
+		return sslCipherSpec;
+	}
+
+	public void setSslCipherSpec(String sslCipherSpec) {
+		this.sslCipherSpec = sslCipherSpec;
+	}
+
+	public boolean isUseIBMCipherMappings() {
+		return useIBMCipherMappings;
+	}
+
+	public void setUseIBMCipherMappings(boolean useIBMCipherMappings) {
+  		System.setProperty("com.ibm.mq.cfg.useIBMCipherMappings", Boolean.toString(useIBMCipherMappings));
+		this.useIBMCipherMappings = useIBMCipherMappings;
+	}
 }

--- a/mq-jms-spring-boot-starter/src/main/java/com/ibm/mq/spring/boot/MQConnectionFactoryFactory.java
+++ b/mq-jms-spring-boot-starter/src/main/java/com/ibm/mq/spring/boot/MQConnectionFactoryFactory.java
@@ -77,6 +77,12 @@ class MQConnectionFactoryFactory {
         cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
       }
 
+      if (!isNullOrEmpty(this.properties.getSslCipherSuite()))
+        cf.setStringProperty(WMQConstants.WMQ_SSL_CIPHER_SUITE, this.properties.getSslCipherSuite());
+
+      if (!isNullOrEmpty(this.properties.getSslCipherSpec()))
+        cf.setStringProperty(WMQConstants.WMQ_SSL_CIPHER_SPEC, this.properties.getSslCipherSpec());
+
       customize(cf);
       return cf;
     }

--- a/mq-jms-spring-boot-starter/src/test/java/com/ibm/mq/spring/boot/MQPropertiesTest.java
+++ b/mq-jms-spring-boot-starter/src/test/java/com/ibm/mq/spring/boot/MQPropertiesTest.java
@@ -1,0 +1,42 @@
+package com.ibm.mq.spring.boot;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import static org.assertj.core.api.Assertions.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes={MQAutoConfiguration.class})
+@EnableAutoConfiguration
+@TestPropertySource(properties = {
+        "mq.queueManager=QMSET",
+        "mq.channel=CHANNELSET",
+        "mq.connName=CONNSET",
+        "mq.user=USER",
+        "mq.password=PASS",
+        "mq.useIBMCipherMappings=true",
+        "mq.sslCipherSuite=CIPHER_SUITE",
+        "mq.sslCipherSpec=CIPHER_SPEC"
+})
+public class MQPropertiesTest {
+
+    @Autowired
+    MQConfigurationProperties properties;
+
+    @Test
+    public void test() {
+        assertThat(properties.getQueueManager()).isEqualTo("QMSET");
+        assertThat(properties.getChannel()).isEqualTo("CHANNELSET");
+        assertThat(properties.getConnName()).isEqualTo("CONNSET");
+        assertThat(properties.getUser()).isEqualTo("USER");
+        assertThat(properties.getPassword()).isEqualTo("PASS");
+        assertThat(properties.isUseIBMCipherMappings()).isEqualTo(true);
+        assertThat(System.getProperty("com.ibm.mq.cfg.useIBMCipherMappings")).isEqualTo("true");
+        assertThat(properties.getSslCipherSuite()).isEqualTo("CIPHER_SUITE");
+        assertThat(properties.getSslCipherSpec()).isEqualTo("CIPHER_SPEC");
+    }
+}


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-jms-spring/CLA.md)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-jms-spring/CHANGES.md)
- [x] You have completed the PR template below:

## What

add support for TLS related changes

## How

added configuration options to the Properties and set appropriate values on the connection factory

## Testing

test case added, also tested locally with a TLS enabled broker.

## Issues

Links to the github issue(s) (if present) that this pull request is resolving.
