### PR TITLE
Add mqcsqp configuration support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,3 +9,5 @@
 - Change configuration prefix to "ibm.mq" to reduce ambiguities if you have other messaging attributes in the same application
 - Modify build.gradle to make pushing to Maven a more explicit operation
 
+# 0.0.4 (2018-04-02)
+- Allow USER_AUTHENTICATION_MQCSP to be configured from properties

--- a/mq-jms-spring-boot-starter/src/main/java/com/ibm/mq/spring/boot/MQConfigurationProperties.java
+++ b/mq-jms-spring-boot-starter/src/main/java/com/ibm/mq/spring/boot/MQConfigurationProperties.java
@@ -53,6 +53,8 @@ public class MQConfigurationProperties {
 
 	/** MQ password */
 	private String password = "passw0rd";
+        
+        private boolean userAuthentificationMQCSP = true;
 
 	/** For TLS connections, you can set either the sslCipherSuite or sslCipherSpec property.
 	 * For example, "SSL_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
@@ -132,5 +134,14 @@ public class MQConfigurationProperties {
 	public void setUseIBMCipherMappings(boolean useIBMCipherMappings) {
   		System.setProperty("com.ibm.mq.cfg.useIBMCipherMappings", Boolean.toString(useIBMCipherMappings));
 		this.useIBMCipherMappings = useIBMCipherMappings;
+	}
+        
+        public boolean isUserAuthentificationMQCSP() {
+		return userAuthentificationMQCSP;
+	}
+
+	public void setUserAuthentificationMQCSP(boolean userAuthentificationMQCSP) {
+  		System.setProperty("com.ibm.mq.cfg.userAuthentificationMQCSP", Boolean.toString(userAuthentificationMQCSP));
+		this.userAuthentificationMQCSP = userAuthentificationMQCSP;
 	}
 }

--- a/mq-jms-spring-boot-starter/src/main/java/com/ibm/mq/spring/boot/MQConnectionFactoryFactory.java
+++ b/mq-jms-spring-boot-starter/src/main/java/com/ibm/mq/spring/boot/MQConnectionFactoryFactory.java
@@ -75,7 +75,7 @@ class MQConnectionFactoryFactory {
       if (!isNullOrEmpty(u)) {
         cf.setStringProperty(WMQConstants.USERID, u);
         cf.setStringProperty(WMQConstants.PASSWORD, this.properties.getPassword());
-        cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
+        cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, this.properties.isUserAuthentificationMQCSP());
       }
 
       if (!isNullOrEmpty(this.properties.getSslCipherSuite()))

--- a/mq-jms-spring-boot-starter/src/test/java/com/ibm/mq/spring/boot/MQPropertiesTest.java
+++ b/mq-jms-spring-boot-starter/src/test/java/com/ibm/mq/spring/boot/MQPropertiesTest.java
@@ -13,14 +13,15 @@ import static org.assertj.core.api.Assertions.*;
 @SpringBootTest(classes={MQAutoConfiguration.class})
 @EnableAutoConfiguration
 @TestPropertySource(properties = {
-        "mq.queueManager=QMSET",
-        "mq.channel=CHANNELSET",
-        "mq.connName=CONNSET",
-        "mq.user=USER",
-        "mq.password=PASS",
-        "mq.useIBMCipherMappings=true",
-        "mq.sslCipherSuite=CIPHER_SUITE",
-        "mq.sslCipherSpec=CIPHER_SPEC"
+        "ibm.mq.queueManager=QMSET",
+        "ibm.mq.channel=CHANNELSET",
+        "ibm.mq.connName=CONNSET",
+        "ibm.mq.user=USER",
+        "ibm.mq.password=PASS",
+        "ibm.mq.useIBMCipherMappings=true",
+        "ibm.mq.userAuthentificationMQCSP=true",
+        "ibm.mq.sslCipherSuite=CIPHER_SUITE",
+        "ibm.mq.sslCipherSpec=CIPHER_SPEC"
 })
 public class MQPropertiesTest {
 
@@ -35,6 +36,7 @@ public class MQPropertiesTest {
         assertThat(properties.getUser()).isEqualTo("USER");
         assertThat(properties.getPassword()).isEqualTo("PASS");
         assertThat(properties.isUseIBMCipherMappings()).isEqualTo(true);
+        assertThat(properties.isUserAuthentificationMQCSP()).isEqualTo(true);
         assertThat(System.getProperty("com.ibm.mq.cfg.useIBMCipherMappings")).isEqualTo("true");
         assertThat(properties.getSslCipherSuite()).isEqualTo("CIPHER_SUITE");
         assertThat(properties.getSslCipherSpec()).isEqualTo("CIPHER_SPEC");


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-jms-spring/CLA.md)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-jms-spring/CHANGES.md)
- [x] You have completed the PR template below:

## What

Allow USER_AUTHENTICATION_MQCSP to be configured from properties

## How

As other properties

## Testing

As other properties

## Issues

Links to the github issue(s) (if present) that this pull request is resolving.
