### PR TITLE
Simplify connection pool creation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,3 +32,6 @@
 
 # 2.0.9
 - Update dependencies to spring boot 2.1.0
+
+# 2.1.0
+- Simplify connection pool creation using spring boot 2.1.0 resources 

--- a/mq-jms-spring-boot-starter/src/main/java/com/ibm/mq/spring/boot/MQConfigurationProperties.java
+++ b/mq-jms-spring-boot-starter/src/main/java/com/ibm/mq/spring/boot/MQConfigurationProperties.java
@@ -14,10 +14,9 @@
 
 package com.ibm.mq.spring.boot;
 
+import org.springframework.boot.autoconfigure.jms.JmsPoolConnectionFactoryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
-
-import java.time.Duration;
 
 /**
  * There are many properties that can be set on an MQ Connection Factory, but these are the most commonly-used
@@ -120,7 +119,7 @@ public class MQConfigurationProperties {
 	private String ccdtUrl;
 
 	@NestedConfigurationProperty
-	private PoolProperties pool = new PoolProperties();
+	private JmsPoolConnectionFactoryProperties pool = new JmsPoolConnectionFactoryProperties();
 
 
 	public String getQueueManager() {
@@ -220,121 +219,8 @@ public class MQConfigurationProperties {
 		this.ccdtUrl = ccdtUrl;
 	}
 
-	public PoolProperties getPool() {
+	public JmsPoolConnectionFactoryProperties getPool() {
 		return pool;
-	}
-
-
-	class PoolProperties {
-
-		/**
-		 * Whether a JmsPoolConnectionFactory should be created, instead of a regular
-		 * ConnectionFactory.
-		 */
-		private boolean enabled;
-
-		/**
-		 * Whether to block when a connection is requested and the pool is full. Set it to
-		 * false to throw a "JMSException" instead.
-		 */
-		private boolean blockIfFull = true;
-
-		/**
-		 * Blocking period before throwing an exception if the pool is still full.
-		 */
-		private Duration blockIfFullTimeout = Duration.ofMillis(-1);
-
-		/**
-		 * Connection idle timeout.
-		 */
-		private Duration idleTimeout = Duration.ofSeconds(30);
-
-		/**
-		 * Maximum number of pooled connections.
-		 */
-		private int maxConnections = 1;
-
-		/**
-		 * Maximum number of pooled sessions per connection in the pool.
-		 */
-		private int maxSessionsPerConnection = 500;
-
-		/**
-		 * Time to sleep between runs of the idle connection eviction thread. When negative,
-		 * no idle connection eviction thread runs.
-		 */
-		private Duration timeBetweenExpirationCheck = Duration.ofMillis(-1);
-
-		/**
-		 * Whether to use only one anonymous "MessageProducer" instance. Set it to false to
-		 * create one "MessageProducer" every time one is required.
-		 */
-		private boolean useAnonymousProducers = true;
-
-		public boolean isEnabled() {
-			return this.enabled;
-		}
-
-		public void setEnabled(boolean enabled) {
-			this.enabled = enabled;
-		}
-
-		public boolean isBlockIfFull() {
-			return this.blockIfFull;
-		}
-
-		public void setBlockIfFull(boolean blockIfFull) {
-			this.blockIfFull = blockIfFull;
-		}
-
-		public Duration getBlockIfFullTimeout() {
-			return this.blockIfFullTimeout;
-		}
-
-		public void setBlockIfFullTimeout(Duration blockIfFullTimeout) {
-			this.blockIfFullTimeout = blockIfFullTimeout;
-		}
-
-		public Duration getIdleTimeout() {
-			return this.idleTimeout;
-		}
-
-		public void setIdleTimeout(Duration idleTimeout) {
-			this.idleTimeout = idleTimeout;
-		}
-
-		public int getMaxConnections() {
-			return this.maxConnections;
-		}
-
-		public void setMaxConnections(int maxConnections) {
-			this.maxConnections = maxConnections;
-		}
-
-		public int getMaxSessionsPerConnection() {
-			return this.maxSessionsPerConnection;
-		}
-
-		public void setMaxSessionsPerConnection(int maxSessionsPerConnection) {
-			this.maxSessionsPerConnection = maxSessionsPerConnection;
-		}
-
-		public Duration getTimeBetweenExpirationCheck() {
-			return this.timeBetweenExpirationCheck;
-		}
-
-		public void setTimeBetweenExpirationCheck(Duration timeBetweenExpirationCheck) {
-			this.timeBetweenExpirationCheck = timeBetweenExpirationCheck;
-		}
-
-		public boolean isUseAnonymousProducers() {
-			return this.useAnonymousProducers;
-		}
-
-		public void setUseAnonymousProducers(boolean useAnonymousProducers) {
-			this.useAnonymousProducers = useAnonymousProducers;
-		}
-
 	}
 
 }


### PR DESCRIPTION
Since its now using spring boot 2.1 the connection pool creation can be simplified using newer resources.
 The advantages are:
 1. Less code to maintain;
 2. Every improvement to connection factory pool creation with newer spring boot releases are automatically provided to this module.

Thank you.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-jms-spring/CLA.md)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-jms-spring/CHANGES.md)
- [x] You have completed the PR template below:

## What
Remove unnecessary code 
## How
Due to spring boot 2.1 upgrade there are some resources that can be used

## Testing
Not necessary

## Issues
None