### PR TITLE
Aligned with SpringBoot JTA and external XA providers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,3 +41,7 @@
 - Update dependencies to MQ 9.1.2
 - Update dependencies to spring boot 2.1.3
 - Add applicationName configuration property (#20)
+
+# 2.1.2
+- Add bean instantiation conditions keeping the correct order - XAConnectionFactoryWrapper and after this IBM connection factory
+- Add XA wrapper functionality for external JTA providers and assign the nonXA connection factory

--- a/mq-jms-spring-boot-starter/src/main/java/com/ibm/mq/spring/boot/MQAutoConfiguration.java
+++ b/mq-jms-spring-boot-starter/src/main/java/com/ibm/mq/spring/boot/MQAutoConfiguration.java
@@ -20,9 +20,11 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jms.JmsAutoConfiguration;
 import org.springframework.boot.autoconfigure.jms.JmsProperties;
 import org.springframework.boot.autoconfigure.jms.JndiConnectionFactoryAutoConfiguration;
+import org.springframework.boot.autoconfigure.transaction.jta.JtaAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -31,8 +33,9 @@ import com.ibm.mq.jms.MQConnectionFactory;
 
 
 @Configuration
+@ConditionalOnProperty(prefix="spring.jta", value="enabled", matchIfMissing=true)
 @AutoConfigureBefore(JmsAutoConfiguration.class)
-@AutoConfigureAfter({ JndiConnectionFactoryAutoConfiguration.class })
+@AutoConfigureAfter({ JndiConnectionFactoryAutoConfiguration.class, JtaAutoConfiguration.class})
 @ConditionalOnClass({ ConnectionFactory.class, MQConnectionFactory.class })
 @ConditionalOnMissingBean(ConnectionFactory.class)
 @EnableConfigurationProperties({MQConfigurationProperties.class, JmsProperties.class})


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-jms-spring/CLA.md)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-jms-spring/CHANGES.md)
- [x] You have completed the PR template below:

## What

XA functionality was aligned with other JMS providers (see ActiveMQ) - SpringBoot keeps the specific ordering of instantiation of beans in configurations - firslty the XA wrapper then the resource adapters. Additionally in order to use the JTA provider the connectionFactory has to be wrapped with the abstraction comming from the provider according to the interface.

## How

The order is kept with annotation @AutoconfigureAfter and the wrappeing functionality is done similarly to the ActiveMQ project. Additionally the nonXA bean is kept in the registry for convenience making it possible to autowire in places of the application where the non distributed transaction is needed. 

## Testing

Locally installed the modified version of this starter and used it in the application which connects to the external IBM queue. Tests were done with Atomikos implementation. 

## Issues

Issue was spotted in my team during the migration of one of the app to this IBM starter. The finding was that it is impossible to use XA with SpringBoot and Atomikos for example.
